### PR TITLE
✨ 進捗部屋のカレンダー情報を返すAPI (beta)

### DIFF
--- a/src/RoomsCalendar.Server/Program.cs
+++ b/src/RoomsCalendar.Server/Program.cs
@@ -75,6 +75,8 @@ namespace RoomsCalendar.Server
                     .AddSingleton<TitechRoomsProvider>()
                     .AddKeyedSingleton<IRoomsProvider, TitechRoomsProvider>(ProviderNames.Titech, (sp, _) => sp.GetRequiredService<TitechRoomsProvider>());
 
+                services.AddSingleton<RoomsCalendarProvider>();
+
                 services.AddScoped(sp => new HttpClient { BaseAddress = new(sp.GetRequiredService<NavigationManager>().BaseUri) });
             }
 

--- a/src/RoomsCalendar.Server/RoomsCalendar.Server.csproj
+++ b/src/RoomsCalendar.Server/RoomsCalendar.Server.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.3.0" />
+    <PackageReference Include="Ical.Net" Version="5.1.0" />
     <PackageReference Include="KnoqNet.Extensions.Authentication" Version="0.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />

--- a/src/RoomsCalendar.Server/Services/RoomsCalendarProvider.cs
+++ b/src/RoomsCalendar.Server/Services/RoomsCalendarProvider.cs
@@ -1,0 +1,81 @@
+﻿using RoomsCalendar.Share;
+using RoomsCalendar.Share.Domain;
+
+namespace RoomsCalendar.Server.Services
+{
+    sealed class RoomsCalendarProvider(
+        [FromKeyedServices(ProviderNames.Knoq)] IRoomsProvider roomsProvider,
+        TimeZoneInfo? calendarTimeZone = null)
+    {
+        Ical.Net.Serialization.CalendarSerializer CalendarSerializer { get; init; } = new();
+
+        DateTimeOffset LastUpdatedAt { get; set; }
+
+        readonly SemaphoreSlim _lock = new(1, 1);
+
+        string? _cachedAll = null;
+        string? _cachedExcludeOccupied = null;
+
+        public async ValueTask<string> GetIcalStringAsync(bool excludeOccupied, CancellationToken ct = default)
+        {
+            await _lock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (excludeOccupied)
+                {
+                    throw new NotImplementedException();
+                }
+                else
+                {
+                    if (_cachedAll is null || LastUpdatedAt < roomsProvider.LastUpdatedAt)
+                    {
+                        var rooms = await GetRoomsAsync(ct).ConfigureAwait(false);
+                        _cachedAll = GetIcalStringCore(rooms);
+                        LastUpdatedAt = roomsProvider.LastUpdatedAt;
+                        return _cachedAll;
+                    }
+                    else
+                    {
+                        return _cachedAll;
+                    }
+                }
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+        string GetIcalStringCore(IEnumerable<Room> rooms)
+        {
+            var timeZoneInfo = calendarTimeZone ?? TimeZoneInfo.Utc;
+            Ical.Net.Calendar calendar = new()
+            {
+                ProductId = "-//yuhima03//traP Rooms Calendar v1//JA",
+                Version = "2.0"
+            };
+            calendar.AddTimeZone(timeZoneInfo);
+            calendar.Events.AddRange(rooms.Select(r => new Ical.Net.CalendarComponents.CalendarEvent
+            {
+                Name = "進捗部屋",
+                Location = r.PlaceName,
+                DtStart = new(TimeZoneInfo.ConvertTimeFromUtc(r.AvailableSince.UtcDateTime, timeZoneInfo)),
+                DtEnd = new(TimeZoneInfo.ConvertTimeFromUtc(r.AvailableUntil.UtcDateTime, timeZoneInfo)),
+            }));
+            lock (CalendarSerializer)
+            {
+                return CalendarSerializer.SerializeToString(calendar) ?? string.Empty;
+            }
+        }
+
+        ValueTask<Room[]> GetRoomsAsync(CancellationToken ct = default)
+        {
+            var timeZoneInfo = calendarTimeZone ?? TimeZoneInfo.Utc;
+            DateTimeOffset timeFrom = TimeZoneInfo.ConvertTimeToUtc(
+                TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, timeZoneInfo).Date.AddDays(-14),
+                timeZoneInfo
+            );
+            return roomsProvider.GetRoomsAsync(timeFrom, DateTimeOffset.MaxValue, ct);
+        }
+    }
+}


### PR DESCRIPTION
- `/api/rooms/ical` を実装.
- 14日前以降の全ての進捗部屋情報を返す.
- 占有されている時間帯を省くオプションは未実装.